### PR TITLE
remove dependency on RcppParallel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SurvBoost
 Type: Package
 Title: Gradient Boosting for Survival Data
-Version: 0.1.2
+Version: 0.1.2-1
 Author: Emily Morris, Kevin He, Yanming Li, Yi Li, Jian Kang
 Maintainer: Emily Morris <emorrisl@umich.edu>
 Description: Gradient boosting for optimizing loss functions of different types of survival data, 
@@ -10,7 +10,7 @@ Description: Gradient boosting for optimizing loss functions of different types 
   description of methods. 
 License: GPL-3
 LazyData: TRUE
-LinkingTo: Rcpp, RcppArmadillo, RcppParallel
+LinkingTo: Rcpp, RcppArmadillo
 RoxygenNote: 6.1.1
 Imports: Rcpp, mvtnorm, ggplot2, plyr, reshape2, directlabels 
 NeedsCompilation: yes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# SurvBoost 0.1.3
+
+Removed an (unused) dependency on RcppParallel.
+
 # SurvBoost 0.1.1
 
 No major changes to report yet. 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ High dimensional variable selection method for stratified proportional hazards m
 ### Installation
 
 In order to install the package, several other R packages must be installed. 
-The code relies on Rcpp, RcppArmadillo, and RcppParallel in order to improve computational speed. 
+The code relies on Rcpp and RcppArmadillo in order to improve computational speed. 
 Additionally the survival package is used for simulation and post selection inference and will be required for installation. 
 
 The following line of R code installs the package from CRAN: 

--- a/src/boosting_package.cpp
+++ b/src/boosting_package.cpp
@@ -1,4 +1,3 @@
-# include <RcppParallel.h>
 # include <RcppArmadillo.h>
 # include <sys/time.h>
 # include <vector>
@@ -12,7 +11,7 @@
 
 using namespace std;
 using namespace Rcpp;
-// [[Rcpp::depends(RcppParallel, RcppArmadillo)]]
+// [[Rcpp::depends(RcppArmadillo)]]
 
 // [[Rcpp::plugins(cpp11)]]
 


### PR DESCRIPTION
Fixes https://github.com/EmilyLMorris/survBoost/issues/3.

As far as I can see, `SurvBoost` does not actually make use of the RcppParallel package (it does not make use of `parallelFor()` or `parallelReduce()`).